### PR TITLE
Prevent virtualenv from installing latest setuptools (resolves #22)

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,7 +2,7 @@
 
 # Create Toil venv
 rm -rf .env
-virtualenv .env
+virtualenv --never-download .env
 . .env/bin/activate
 
 # Prepare directory for temp files


### PR DESCRIPTION
This started causing problems with `setup.py upload` not being able to read the credentials from ~/.pypirc anymore, starting with this commit:

https://github.com/pypa/setuptools/commit/7f8144544f23f4fd84d339d846b91d4e3b703dd4

Resolves #22 