### PR TITLE
Add bam validator (resolves #37)

### DIFF
--- a/src/toil_lib/test/test_validators.py
+++ b/src/toil_lib/test/test_validators.py
@@ -1,0 +1,14 @@
+import os
+
+from toil_lib.urls import download_url
+
+
+def test_bam_quickcheck(tmpdir):
+    from toil_lib.validators import bam_quickcheck
+    work_dir = str(tmpdir)
+    good_bam_url = 's3://cgl-pipeline-inputs/exome/ci/chr6.normal.bam'
+    bad_bam_url = 's3://cgl-pipeline-inputs/exome/ci/truncated.bam'
+    download_url(url=good_bam_url, name='good.bam', work_dir=work_dir)
+    download_url(url=bad_bam_url, name='bad.bam', work_dir=work_dir)
+    assert bam_quickcheck(os.path.join(work_dir, 'good.bam'))
+    assert bam_quickcheck(os.path.join(work_dir, 'bad.bam')) == False

--- a/src/toil_lib/validators.py
+++ b/src/toil_lib/validators.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+
+
+from toil_lib import require
+
+
+def bam_quickcheck(bam_path):
+    """
+    Perform a quick check on a BAM via `samtools quickcheck`.
+    This will detect obvious BAM errors such as truncation.
+
+    :param str bam_path: path to BAM file to checked
+
+    :rtype: boolean
+    :return: True if the BAM is valid, False is BAM is invalid or something related to the call went wrong
+    """
+    directory, bam_name = os.path.split(bam_path)
+    exit_code = subprocess.call(['docker', 'run', '-v', directory + ':/data',
+                                 'quay.io/ucsc_cgl/samtools:1.3--256539928ea162949d8a65ca5c79a72ef557ce7c',
+                                 'quickcheck', '-vv', '/data/' + bam_name])
+    if exit_code != 0:
+        return False
+    return True
+
+
+def require_bam_quickcheck(bam_path):
+    require(bam_quickcheck(bam_path), "The BAM at '%s' is invalid or something else is wrong!" % bam_path)


### PR DESCRIPTION
Resolve #37 

As always, Docker makes things really annoying. Any use of `timeout` outside the `docker run` step or within the container caused problems where it either didn't work as expected or it created a ghost container which quickly ate all the available disk space due to stdout writing to docker logs. 

I found the `--ulimit cpu=1` trick somewhere and it works.  Due to needing to pipe stdout/stderr I couldn't repurpose `docker_call`.

I tested this by using a sorted bam from STAR and then creating a truncated version with `sed`.  The good bam returns `True`, the truncated bam returns `False`.