### PR TITLE
Return log.final.out from STAR (resolves #47)

### DIFF
--- a/src/toil_lib/tools/aligners.py
+++ b/src/toil_lib/tools/aligners.py
@@ -59,11 +59,12 @@ def run_star(job, r1_id, r2_id, star_index_url, wiggle=False):
     # Write to fileStore
     transcriptome_id = job.fileStore.writeGlobalFile(os.path.join(work_dir, 'rnaAligned.toTranscriptome.out.bam'))
     sorted_id = job.fileStore.writeGlobalFile(os.path.join(work_dir, 'rnaAligned.sortedByCoord.out.bam'))
+    log_id = job.fileStore.writeGlobalFile(os.path.join(work_dir, 'rnaLog.final.out'))
     if wiggle:
         wiggle_id = job.fileStore.writeGlobalFile(os.path.join(work_dir, 'rnaSignal.UniqueMultiple.str1.out.bg'))
-        return transcriptome_id, sorted_id, wiggle_id
+        return transcriptome_id, sorted_id, wiggle_id, log_id
     else:
-        return transcriptome_id, sorted_id
+        return transcriptome_id, sorted_id, log_id
 
 
 def run_bwakit(job, config, sort=True, trim=False):


### PR DESCRIPTION
Needed by CKCC for QC. This breaks backwards compatability but only toil-rnaseq uses this function as of now.