### PR TITLE
Revert "Within KeepPairs" to "Within" (resolves #85)

### DIFF
--- a/src/toil_lib/tools/aligners.py
+++ b/src/toil_lib/tools/aligners.py
@@ -32,7 +32,7 @@ def run_star(job, r1_id, r2_id, star_index_url, wiggle=False):
                   '--genomeDir', star_index,
                   '--outFileNamePrefix', 'rna',
                   '--outSAMtype', 'BAM', 'SortedByCoordinate',
-                  '--outSAMunmapped', 'Within KeepPairs',
+                  '--outSAMunmapped', 'Within',
                   '--quantMode', 'TranscriptomeSAM',
                   '--outSAMattributes', 'NH', 'HI', 'AS', 'NM', 'MD',
                   '--outFilterType', 'BySJout',


### PR DESCRIPTION
Causes downstream expression differences in pipeline.